### PR TITLE
Added Functionality: Config Parameters for xml rpc communication back to...

### DIFF
--- a/openerp_addon/pentaho_reports/core.py
+++ b/openerp_addon/pentaho_reports/core.py
@@ -44,10 +44,15 @@ def get_proxy_args(cr, uid, prpt_content):
 
     proxy_url = config_obj.get_param(cr, uid, 'pentaho.server.url', default='http://localhost:8080/pentaho-reports-for-openerp')
 
+    
+    
+    xml_interface = config_obj.get_param(cr, uid, 'pentaho.openerp.xml.interface', default='localhost') ## Could do something with the old way config["xmlrpc_interface"] or "localhost"
+    xml_port = config_obj.get_param(cr, uid, 'pentaho.openerp.xml.port', default='8069') ## Could do something with the old way str(config["xmlrpc_port"])
+        
     proxy_argument = {
                       "prpt_file_content": xmlrpclib.Binary(prpt_content),
-                      "connection_settings" : {'openerp' : {"host": config["xmlrpc_interface"] or "localhost",
-                                                            "port": str(config["xmlrpc_port"]), 
+                      "connection_settings" : {'openerp' : {"host": xml_interface,
+                                                            "port": xml_port, 
                                                             "db": cr.dbname,
                                                             "login": current_user.login,
                                                             "password": current_user.password,

--- a/openerp_addon/pentaho_reports/data/config_data.xml
+++ b/openerp_addon/pentaho_reports/data/config_data.xml
@@ -5,6 +5,17 @@
 			<field name="key">pentaho.server.url</field>
 			<field name="value">http://localhost:8080/pentaho-reports-for-openerp</field>
 		</record>
+		
+		<record id="pentaho_openerp_xml_interface" model="ir.config_parameter">
+			<field name="key">pentaho.openerp.xml.interface</field>
+			<field name="value">localhost</field>
+		</record>
+		
+		<record id="pentaho_openerp_xml_port" model="ir.config_parameter">
+			<field name="key">pentaho.openerp.xml.port</field>
+			<field name="value">8069</field>
+		</record>
+		
 
 		<record id="pentaho_postgres_host" model="ir.config_parameter">
 			<field name="key">pentaho.postgres.host</field>


### PR DESCRIPTION
Hi There,

I've added a system parameter for XMLRPC interface and XMLRPC port in cases when you seperate both servers and the OpenERP server needs to interact on more then one interface you want to leave the xmlrpc interface option empty in the config file. But the pentaho module assumes he will work on localhost wich is not the case.

Could you merge this with 61 and 70?

André Schenkels
ICTSTUDIO
