### PR TITLE
[FIX] XMLRPC localhost issue with version 7

### DIFF
--- a/openerp_addon/pentaho_reports/core.py
+++ b/openerp_addon/pentaho_reports/core.py
@@ -44,10 +44,14 @@ def get_proxy_args(cr, uid, prpt_content):
 
     proxy_url = config_obj.get_param(cr, uid, 'pentaho.server.url', default='http://localhost:8080/pentaho-reports-for-openerp')
 
+    xml_interface = config_obj.get_param(cr, uid, 'pentaho.openerp.xml.interface', default='localhost') ## Could do something with the old way config["xmlrpc_interface"] or "localhost"
+    xml_port = config_obj.get_param(cr, uid, 'pentaho.openerp.xml.port', default='8069') ## Could do something with the old way str(config["xmlrpc_port"])
+   
+
     proxy_argument = {
                       "prpt_file_content": xmlrpclib.Binary(prpt_content),
-                      "connection_settings" : {'openerp' : {"host": config["xmlrpc_interface"] or "localhost",
-                                                            "port": str(config["xmlrpc_port"]), 
+                      "connection_settings" : {'openerp' : {"host": xml_interface,
+                                                            "port": xml_port, 
                                                             "db": cr.dbname,
                                                             "login": current_user.login,
                                                             "password": current_user.password,

--- a/openerp_addon/pentaho_reports/data/config_data.xml
+++ b/openerp_addon/pentaho_reports/data/config_data.xml
@@ -6,6 +6,16 @@
 			<field name="value">http://localhost:8080/pentaho-reports-for-openerp</field>
 		</record>
 
+		<record id="pentaho_openerp_xml_interface" model="ir.config_parameter">
+			<field name="key">pentaho.openerp.xml.interface</field>
+			<field name="value">localhost</field>
+		</record>
+		
+		<record id="pentaho_openerp_xml_port" model="ir.config_parameter">
+			<field name="key">pentaho.openerp.xml.port</field>
+			<field name="value">8069</field>
+		</record>
+		
 		<record id="pentaho_postgres_host" model="ir.config_parameter">
 			<field name="key">pentaho.postgres.host</field>
 			<field name="value">localhost</field>


### PR DESCRIPTION
If you want to run OpenERP and the Pentaho Report Server on 2 different servers you can have a problem with the dependicie of the pentaho openerp module on the XMLRPC interface setting of the OpenERP config. 
In the case you have more as 1 interface you need to set it to empty. If this value is empty the Pentaho Server will comunicate back to localhost and there will be no OpenERP server in this case.
This FIX will provide you extra system parameters to set the XMLRPC interface.
