### PR TITLE
Remove "Pentaho Reports" as a menu option in its own right.

### DIFF
--- a/openerp_addon/pentaho_reports/report_xml_view.xml
+++ b/openerp_addon/pentaho_reports/report_xml_view.xml
@@ -4,78 +4,59 @@
 		<record id="act_report_xml_view_pent" model="ir.ui.view">
 			<field name="name">ir.actions.report.xml.pentaho.reports</field>
 			<field name="model">ir.actions.report.xml</field>
-			<field name="type">form</field>
 			<field name="inherit_id" ref="base.act_report_xml_view"/>
 			<field name="arch" type="xml">
 				<field name="report_name" position="after">
-					<field name="pentaho_report_output_type"/>
+					<field name="is_pentaho_report"/>
+				</field>
+				<field name="model" position='attributes'>
+					<attribute name='attrs'>{'invisible': [('is_pentaho_report', '=', True)]}</attribute>
+				</field>
+				<field name="report_type" position='attributes'>
+					<attribute name='attrs'>{'invisible': [('is_pentaho_report', '=', True)]}</attribute>
+				</field>
+				<field name="report_file" position='attributes'>
+					<attribute name='attrs'>{'invisible': [('is_pentaho_report', '=', True)]}</attribute>
+				</field>
+				<field name='model' postion='after'>
+					<field name="pentaho_report_model_id" attrs="{'invisible': [('is_pentaho_report', '!=', True)], 'required': [('is_pentaho_report', '=', True)]}"/>
+					<field name='linked_menu_id' attrs="{'invisible': [('is_pentaho_report', '!=', True)]}"/>
+				</field>
+				<field name='report_file' position='after'>
+					<field name="pentaho_report_output_type" attrs="{'invisible': [('is_pentaho_report', '!=', True)], 'required': [('is_pentaho_report', '=', True)]}"/>
+					<field name="pentaho_file" filename="pentaho_filename" attrs="{'invisible': [('is_pentaho_report', '!=', True)], 'required': [('is_pentaho_report', '=', True)]}"/>
+					<field name="pentaho_filename" attrs="{'required': [('is_pentaho_report', '=', True)]}" invisible='1'/>
+				</field>
+				<group string="RML Report" position='attributes'>
+					<attribute name='attrs'>{'invisible': [('is_pentaho_report', '=', True)]}</attribute>
+				</group>
+				<group string="XML Report" position='attributes'>
+					<attribute name='attrs'>{'invisible': [('is_pentaho_report', '=', True)]}</attribute>
+				</group>
+			</field>
+		</record>
+
+		<record id="act_report_xml_view_tree_pent" model="ir.ui.view">
+			<field name="name">ir.actions.report.xml.tree.pentaho</field>
+			<field name="model">ir.actions.report.xml</field>
+			<field name="inherit_id" ref="base.act_report_xml_view_tree"/>
+			<field name="arch" type="xml">
+				<field name='type' position='after'>
+					<field name="is_pentaho_report" string="Pentaho"/>
 				</field>
 			</field>
 		</record>
 
-		<record id="act_report_pentaho_report_form" model="ir.ui.view">
-			<field name="name">ir.actions.report.pentaho.report.form</field>
+		<record id="act_report_xml_search_view_pent" model="ir.ui.view">
+			<field name="name">ir.actions.report.xml.search.pentaho</field>
 			<field name="model">ir.actions.report.xml</field>
-			<field name="type">form</field>
-			<field name="priority">20</field>
+			<field name="inherit_id" ref="base.act_report_xml_search_view"/>
 			<field name="arch" type="xml">
-			<form string="Pentaho reports">
-				<field name="name" select="1"/>
-				<field name="pentaho_report_model_id" required="True" select="1"/>
-				<field name="report_name" select="1"/>
-				<field name="pentaho_report_output_type" required="True" select="1"/>
-				<field name="attachment"/>
-				<field name="attachment_use"/>
-				<field name='linked_menu_id'/>
-				<newline/>
-				<field name="pentaho_file" filename="pentaho_filename" required="True" colspan="4"/>
-				<field name="pentaho_filename" colspan="4" required="True" invisible='1'/>
-				<separator string="Groups" colspan="4"/>
-				<field name="groups_id" colspan="4" nolabel="1" />
-			</form>
+				<search position='inside'>
+					<filter string="Pentaho Reports" name="pentaho_reports" domain="[('is_pentaho_report', '=', True)]"/>
+				</search>
 			</field>
 		</record>
 
-		<record id="act_report_pentaho_report_tree" model="ir.ui.view">
-			<field name="name">ir.actions.report.pentaho.report.tree</field>
-			<field name="model">ir.actions.report.xml</field>
-			<field name="type">tree</field>
-			<field name="priority">20</field>
-			<field name="arch" type="xml">
-			<tree string="Pentaho reports">
-				<field name="name"/>
-				<field name="pentaho_report_model_id"/>
-				<field name="report_name"/>
-				<field name="pentaho_report_output_type"/>
-				<field name="attachment"/>
-			</tree>
-			</field>
-		</record>
-
-		<record id="ir_action_report_pentaho_report" model="ir.actions.act_window">
-			<field name="name">Pentaho Reports</field>
-			<field name="type">ir.actions.act_window</field>
-			<field name="res_model">ir.actions.report.xml</field>
-			<field name="view_type">form</field>
-			<field name="view_mode">tree,form</field>
-			<field name="context">{'is_pentaho_report': True}</field>
-			<field name="domain">[('is_pentaho_report', '=', True)]</field>
-		</record>
-
-		<record id="ir_action_report_pentaho_report_view0" model="ir.actions.act_window.view">
-			<field name="act_window_id" ref="ir_action_report_pentaho_report"/>
-			<field name="view_mode">tree</field>
-			<field name="view_id" ref="act_report_pentaho_report_tree"/>
-			<field name="sequence">0</field>
-		</record>
-
-		<record id="ir_action_report_pentaho_report_view1" model="ir.actions.act_window.view">
-			<field name="act_window_id" ref="ir_action_report_pentaho_report"/>
-			<field name="view_mode">form</field>
-			<field name="view_id" ref="act_report_pentaho_report_form"/>
-			<field name="sequence">1</field>
-		</record>
-
-		<menuitem action="ir_action_report_pentaho_report" id="menu_ir_action_report_pentaho_report" parent="base.next_id_6"/> 
 	</data>
 </openerp>


### PR DESCRIPTION
Combine with OpenERP reports views.

Allows Reports to be switched from one type to the other.

Closes #41
