### PR TITLE
Changes required to complete a build against Pentaho 5.1 or trunk as requested in #121

### DIFF
--- a/java_server/build.properties
+++ b/java_server/build.properties
@@ -1,4 +1,4 @@
-project.revision=7.5.1
+project.revision=8.0.1
 ivy.artifact.group=com.willowit
 ivy.artifact.id=pentaho-reports-for-openerp
 impl.title=Pentaho Reports for OpenERP
@@ -19,4 +19,4 @@ project.use-full-dist=true
 ivy.default.sub-configs=internal,external
 ivy.use.symlinks=false
 
-pentaho-reporting.version=5.0-SNAPSHOT
+pentaho-reporting.version=5.1-SNAPSHOT

--- a/java_server/ivy.xml
+++ b/java_server/ivy.xml
@@ -51,10 +51,10 @@
     <dependency org="pentaho-reporting-engine" name="pentaho-reporting-engine-classic-extensions-openerp" 
                 rev="${pentaho-reporting.version}" transitive="true" changing="true"/>
     
-    <dependency org="javax.servlet"      name="servlet-api"   rev="2.5"           transitive="false" />
-    <dependency org="org.apache.xmlrpc"  name="xmlrpc-server" rev="3.1.3"         transitive="false" />
-    <dependency org="org.apache.commons" name="commons-lang3" rev="3.1"           transitive="false" />
-    <dependency org="postgresql"         name="postgresql"    rev="9.1-902.jdbc4" transitive="false" />
+    <dependency org="javax.servlet"      name="servlet-api"   rev="2.5"            transitive="false" />
+    <dependency org="org.apache.xmlrpc"  name="xmlrpc-server" rev="3.1.3"          transitive="false" />
+    <dependency org="org.apache.commons" name="commons-lang3" rev="3.1"            transitive="false" />
+    <dependency org="org.postgresql"     name="postgresql"    rev="9.3-1102-jdbc4" transitive="false" />
     
     <!-- Test Build Dependencies -->
     <dependency org="junit" name="junit" rev="4.10" transitive="false" conf="test->default"/>

--- a/java_server/ivysettings.xml
+++ b/java_server/ivysettings.xml
@@ -4,6 +4,11 @@
   <property name="ivy.local.default.root" value="${ivy.default.ivy.user.dir}/local" override="true" />
   <property name="ivy.local.default.artifact.pattern" value="[organisation]/[module]/[revision]/[type]s/[artifact]-[revision].[ext]"
     override="false" />
+    
+  <!-- Repository for Pentaho-hosted artifacts -->  
+  <property name="pentaho.resolve.repo" value="http://repo.pentaho.org/artifactory/repo" override="false" />
+  <!-- Repository for External-hosted artifacts (Optional. Defaults to Pentaho-hosted.) -->
+  <property name="public.resolve.repo" value="${pentaho.resolve.repo}" override="false" />
 
   <settings defaultResolver="pentaho-chained-resolver" />
   <include url="${ivy.default.settings.dir}/ivysettings-public.xml" />
@@ -13,12 +18,11 @@
       <resolver ref="local" />
       <dual name="pentaho">
         <url name="pentaho-ivy">
-          <ivy pattern="http://repo.pentaho.org/artifactory/repo/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />
+          <ivy pattern="${pentaho.resolve.repo}/[organisation]/[module]/[revision]/[module]-[revision].ivy.xml" />
         </url>
-        <ibiblio name="pentaho-mvn" m2compatible="true" root="http://repo.pentaho.org/artifactory/repo" />
+        <ibiblio name="pentaho-mvn" m2compatible="true" root="${pentaho.resolve.repo}" />
       </dual>
-      <resolver ref="public" />
-      <ibiblio name="java-net-maven2" root="http://download.java.net/maven/2/" m2compatible="true" />
+      <ibiblio name="public-maven" root="${public.resolve.repo}" m2compatible="true" />
     </chain>
   </resolvers>
   <caches lockStrategy="artifact-lock" resolutionCacheDir="${ivy.default.ivy.user.dir}/resol-cache${env.EXECUTOR_NUMBER}" />


### PR DESCRIPTION
Applied Pentaho repository fixes, fixed PostgreSQL dependency and updated project to build against Pentaho 5.1.  The commits are separated so it can be cherry-picked to other branches if you want to build against older versions of OpenERP/Pentaho.
