### PR TITLE
Added 'context' paramter to pentaho report

### DIFF
--- a/openerp_addon/pentaho_reports/java_oe.py
+++ b/openerp_addon/pentaho_reports/java_oe.py
@@ -104,6 +104,7 @@ RESERVED_PARAMS = {
                    'user_name': lambda s, cr, uid, d: d.get('uid') and s.pool.get('res.users').browse(cr, uid, d['uid'], context=d.get('context')).name or '',
                    'context_lang': lambda s, cr, uid, d: d.get('context', {}).get('lang', ''),
                    'context_tz': lambda s, cr, uid, d: d.get('context', {}).get('tz', ''),
+                   'context': lambda s, cr, uid, d: d.get('context', {})
                    }
 
 


### PR DESCRIPTION
In cases when report uses a custom function it is convenient to pass additional parameters in context to the function. This change enables context passing to the pentaho report.
