### PR TITLE
pentaho_report. Fix to method pentaho_report_action().

### DIFF
--- a/openerp_addon/pentaho_reports/ui.py
+++ b/openerp_addon/pentaho_reports/ui.py
@@ -335,7 +335,7 @@ class report_xml(models.Model):
             raise except_orm(_('Error'), _("Report '%s' must be passed active ids or parameter values.") % service_name)
 
         datas = {'model': report.model,
-                 'output_type': report.report_type,
+                 'report_type': report.report_type,
                 }
 
         if active_ids:


### PR DESCRIPTION
In v8 need to return 'report_type' not 'output_type'.
