### PR TITLE
Changes due to cache flushing.

### DIFF
--- a/openerp_addon/pentaho_reports/__init__.py
+++ b/openerp_addon/pentaho_reports/__init__.py
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 import core
+import core_newapi
 import ui
 import java_oe
 import wizard

--- a/openerp_addon/pentaho_reports/__openerp__.py
+++ b/openerp_addon/pentaho_reports/__openerp__.py
@@ -177,7 +177,7 @@ that you would consider worth sharing, please email them through with some descr
     "version": "0.1",
     "author": "WillowIT Pty Ltd",
     "website": "http://www.willowit.com.au/",
-    "depends": ["base"],
+    "depends": ["base", "mail"],
     "category": "Reporting subsystems",
     "data": [
              "report_xml_view.xml",

--- a/openerp_addon/pentaho_reports/core_newapi.py
+++ b/openerp_addon/pentaho_reports/core_newapi.py
@@ -1,0 +1,111 @@
+# -*- encoding: utf-8 -*-
+
+# As code is written in the new_api structure, it should go in here and be removed from core.py
+
+from openerp import models, fields, api, _
+from openerp.exceptions import except_orm
+
+from openerp import sql_db
+
+PENTAHO_TEMP_USER_PW = 'TempPWPentaho'
+PENTAHO_TEMP_USER_LOGIN = '%s (Pentaho)'
+
+class res_users(models.Model):
+    _inherit = 'res.users'
+
+    #Fudge to fix bad base code....
+    def _create_welcome_message(self, cr, uid, user, context=None):
+        if context is None:
+            context = {}
+        if context.get('dont_welcome'):
+            return False
+        super(res_users, self)._create_welcome_message(cr, uid, user, context=context)
+
+    @api.multi
+    def pentaho_temp_user_find(self):
+        self.ensure_one()
+        user = self.sudo().browse(self.id)
+        temp_users = self.sudo().search([('login', '=', PENTAHO_TEMP_USER_LOGIN % user.login)])
+        if not temp_users:
+            self.pentaho_temp_user_create()
+        return PENTAHO_TEMP_USER_LOGIN % user.login
+
+    @api.multi
+    def pentaho_temp_user_create(self):
+        self.ensure_one()
+        self.pentaho_temp_users_unlink()
+        with api.Environment.manage():
+            new_cr = sql_db.db_connect(self.env.cr.dbname).cursor()
+            new_env = self.env(new_cr, self.env.uid, {'no_reset_password': True,
+                                                      'tracking_disable': True,
+                                                      'dont_welcome': True,
+                                                      'skip_cleanup': True,
+                                                      })
+            user = self.with_env(new_env).sudo().browse(self.id)
+            new_user = self.with_env(new_env).sudo().copy(default={'login': PENTAHO_TEMP_USER_LOGIN % user.login,
+                                                                   'password': PENTAHO_TEMP_USER_PW,
+                                                                   'user_ids': False,
+                                                                   'message_ids': False,
+                                                                   'name': user.name,
+                                                                   'groups_id': False,
+                                                                   })
+            #
+            # This next bit of code is awful.  BUT, writing a value to groups_id has an explicit "invalidate_cache".  This
+            # nasty generally has no impact on the overall scheme of things, BUT, when the pentaho report is called from
+            # on change in the mail compose wizard, the invalidate cache causes the on screen wizard to be invalidated!!!!
+            #
+            # This specific insert of securities ensures we don't end up in that rabbit hole
+            #
+            for g in user.groups_id.ids:
+                if not g in new_user.groups_id.ids:
+                    new_cr.execute("""INSERT INTO res_groups_users_rel
+                                        (uid, gid) VALUES
+                                        (%s, %s);""", (new_user.id, g))
+            new_cr.commit()
+            new_cr.close()
+        return new_user.id
+
+    @api.multi
+    def pentaho_temp_users_unlink(self):
+        with api.Environment.manage():
+            new_cr = sql_db.db_connect(self.env.cr.dbname).cursor()
+            new_env = self.env(new_cr, self.env.uid, {})
+            self.with_env(new_env)._pentaho_temp_users_unlink()
+            new_cr.commit()
+            new_cr.close()
+
+    @api.multi
+    def _pentaho_temp_users_unlink(self):
+        """Unlink users and associated partners.
+        """
+        existing_users = self.sudo().browse()
+        existing_partners = self.sudo().env['res.partner']
+        for user in self.sudo().browse(self.ids):
+            existing_users += self.sudo().search([('login', '=', PENTAHO_TEMP_USER_LOGIN % user.login)])
+        for user in existing_users:
+            if user.partner_id:
+                existing_partners += user.partner_id
+
+#         existing_users.unlink()
+#         existing_partners.unlink()
+        if existing_users:
+            #
+            # Again, caching issues in base odoo bite us, so remove records manually...
+            #
+            if 1 in existing_users.ids:
+                existing_users = existing_users - self.sudo().browse(1)
+            self.env.cr.execute("""DELETE FROM res_users WHERE id IN %s;""", (tuple(existing_users.ids),))
+        if existing_partners:
+            #
+            # Again, caching issues in base odoo bite us, so remove records manually...
+            #
+            self.env.cr.execute("""DELETE FROM res_partner WHERE id IN %s;""", (tuple(existing_partners.ids),))
+
+    @api.multi
+    def write(self, values):
+        #
+        # Crude clean-up code - if something writes to res_users then assume it is OK to clean up temp users...
+        #
+        if not self.env.context.get('skip_cleanup'):
+            self.pentaho_temp_users_unlink()
+        return super(res_users, self).write(values)


### PR DESCRIPTION
Creating users / partners on the fly was causing a problem in on change on email template.

Various interactions between old api and new api within standard odoo user creations had code which
invalidated the cache.  This was a problem for the wizard cache which called the onchange which
called the report in preview mode.

Some of the fix is nasty code, BUT it is autonomous...

We are still looking for a better and cleaner solution, long term.
