### PR TITLE
ir.model.access.csv missing in __openerp__.py

### DIFF
--- a/openerp_addon/pentaho_reports_auth_crypt/__openerp__.py
+++ b/openerp_addon/pentaho_reports_auth_crypt/__openerp__.py
@@ -15,6 +15,7 @@ This module provides support for Pentaho Reports where the auth_crypt (password 
 module has been installed.
     """,
     'data': [
+            "security/ir.model.access.csv",
             ],
     'demo': [],
     'test': [],


### PR DESCRIPTION
If you try to print as "simple user" you get an error.
Rights are missing because file ir.model.access.csv is not added in **openerp**.py
