### PR TITLE
docker support

### DIFF
--- a/java_server/Dockerfile.in
+++ b/java_server/Dockerfile.in
@@ -1,0 +1,3 @@
+from tomcat:8
+run rm -rf /usr/local/tomcat/webapps/*
+add @war_file@ /usr/local/tomcat/webapps/ROOT.war

--- a/java_server/build.xml
+++ b/java_server/build.xml
@@ -71,7 +71,22 @@
         <zipfileset dir="${src.dir}" includes="**/*.properties" prefix="WEB-INF/classes"/>
       </war>
     </target>
-    
+
+    <target name="docker"
+            depends="war">
+      <copy file="Dockerfile.in" tofile="${dist.dir}/Dockerfile" filtering="true">
+        <filterset>
+          <filter token="war_file" value="${ivy.artifact.id}-${project.revision}.war" />
+        </filterset>
+      </copy>
+      <exec executable="docker" failonerror="true">
+        <arg value="build"/>
+        <arg value="-t"/>
+        <arg value="${ivy.artifact.id}:${project.revision}"/>
+        <arg value="dist"/>
+      </exec>
+    </target>
+
     <!-- Build and launch the application -->
     <target name="launch" depends="jar">
       <java classname="${standalone-server-class}" fork="true">


### PR DESCRIPTION
As promised in #248 here is way to build a docker from the war, using ant.

Just run `ant docker` to get an image named `pentaho-reports-for-openerp:{version}`.

/cc @richard-willowit 
