### PR TITLE
Check for leaked connections and close them

### DIFF
--- a/java_server/Dockerfile.in
+++ b/java_server/Dockerfile.in
@@ -1,0 +1,3 @@
+from tomcat:8
+run rm -rf /usr/local/tomcat/webapps/*
+add @war_file@ /usr/local/tomcat/webapps/ROOT.war

--- a/java_server/build.xml
+++ b/java_server/build.xml
@@ -71,7 +71,22 @@
         <zipfileset dir="${src.dir}" includes="**/*.properties" prefix="WEB-INF/classes"/>
       </war>
     </target>
-    
+
+    <target name="docker"
+            depends="war">
+      <copy file="Dockerfile.in" tofile="${dist.dir}/Dockerfile" filtering="true">
+        <filterset>
+          <filter token="war_file" value="${ivy.artifact.id}-${project.revision}.war" />
+        </filterset>
+      </copy>
+      <exec executable="docker" failonerror="true">
+        <arg value="build"/>
+        <arg value="-t"/>
+        <arg value="${ivy.artifact.id}:${project.revision}"/>
+        <arg value="dist"/>
+      </exec>
+    </target>
+
     <!-- Build and launch the application -->
     <target name="launch" depends="jar">
       <java classname="${standalone-server-class}" fork="true">

--- a/java_server/src/com/willowit/application/PentahoResourceChecker.java
+++ b/java_server/src/com/willowit/application/PentahoResourceChecker.java
@@ -1,6 +1,10 @@
 package com.willowit.application;
 
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.LinkedList;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -10,11 +14,28 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class PentahoResourceChecker implements Filter {
+	
+	private static ThreadLocal<Collection<Connection>> connections = new ThreadLocal<Collection<Connection>>() {
+		protected java.util.Collection<Connection> initialValue() {
+			return new LinkedList<Connection>();
+		};
+	};
+
+	public static void registerConnection(Connection conn) {
+		connections.get().add(conn);
+	}
+	
+	private Logger log;
+	
 	private FilterConfig config;
 
 	public void init(FilterConfig config) throws ServletException {
 		this.config = config;
+		this.log = LoggerFactory.getLogger(getClass());
 	}
 
 	public void destroy() {
@@ -23,9 +44,32 @@ public class PentahoResourceChecker implements Filter {
 	public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
 		Boolean pentaho_boot = (Boolean) config.getServletContext().getAttribute("pentaho_boot_success");
 
-		if(pentaho_boot != null && pentaho_boot.booleanValue())
-			chain.doFilter(req, resp);
-		else
-			((HttpServletResponse) resp).sendError(404, "Pentaho boot failure!");
+		try {
+			if(pentaho_boot != null && pentaho_boot.booleanValue())
+				chain.doFilter(req, resp);
+			else
+				((HttpServletResponse) resp).sendError(404, "Pentaho boot failure!");
+		} finally {
+			closeAllConnections();
+		}
+	}
+
+	private void closeAllConnections() {
+		for (Connection conn: connections.get()) {
+			try {
+				if (conn.isClosed()) {
+					continue;
+				}
+				log.warn("Found an open connection after request", conn);
+			} catch (SQLException e) {
+				log.warn("Failed to check if connection was closed", e);
+			}
+			try {
+				conn.close();
+			} catch (SQLException e) {
+				log.warn("Failed to close connection", e);
+			}
+		}
+		connections.get().clear();
 	}
 }

--- a/java_server/src/com/willowit/reporting/PentahoRenderer.java
+++ b/java_server/src/com/willowit/reporting/PentahoRenderer.java
@@ -1,6 +1,8 @@
 package com.willowit.reporting;
 
 import java.io.ByteArrayOutputStream;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -42,6 +44,7 @@ import org.pentaho.reporting.libraries.resourceloader.Resource;
 import org.pentaho.reporting.libraries.resourceloader.ResourceManager;
 
 import com.debortoliwines.openerp.reporting.di.OpenERPFilterInfo;
+import com.willowit.application.PentahoResourceChecker;
 
 public class PentahoRenderer {
 	private static Log logger = LogFactory.getLog(PentahoRenderer.class);
@@ -138,7 +141,17 @@ public class PentahoRenderer {
 
 		String jdbc_url = "jdbc:postgresql://" + postgres_host + ":" + postgres_port + "/" + postgres_db;
 
-		new_settings = new DriverConnectionProvider();
+		new_settings = new DriverConnectionProvider() {
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public Connection createConnection(String user, String password)
+					throws SQLException {
+				Connection conn = super.createConnection(user, password);
+				PentahoResourceChecker.registerConnection(conn);
+				return conn;
+			}
+		};
 		new_settings.setDriver("org.postgresql.Driver");
 		new_settings.setUrl(jdbc_url);
 		new_settings.setProperty("user", postgres_login);


### PR DESCRIPTION
Hi,

during our tests, we've seen SQL connection leaks. Here is a patch to close the leaks so they don't DoS PostgreSQL. It may be better to find a way to use a connection pool, though, but this patch is the smallest possible fix I could think of.

It also contains the docker support PR, tell me if you want me to cherry-pick the fix alone in this PR.

Thanks!
