### PR TITLE
Make Ivy configuration relative to the project, not the workspace

### DIFF
--- a/java_server/.classpath
+++ b/java_server/.classpath
@@ -13,7 +13,7 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.module.container"/>
-	<classpathentry kind="con" path="org.apache.ivyde.eclipse.cpcontainer.IVYDE_CONTAINER/?project=java_server&amp;ivyXmlPath=ivy.xml&amp;confs=*&amp;ivySettingsPath=%24%7Bworkspace_loc%3Ajava_server%2Fivysettings.xml%7D&amp;loadSettingsOnDemand=false&amp;propertyFiles=build.properties">
+	<classpathentry kind="con" path="org.apache.ivyde.eclipse.cpcontainer.IVYDE_CONTAINER/?project=pentaho+-+8.0+Java+Server&amp;ivyXmlPath=ivy.xml&amp;confs=*&amp;ivySettingsPath=ivysettings.xml&amp;loadSettingsOnDemand=false&amp;ivyUserDir=&amp;propertyFiles=build.properties">
 		<attributes>
 			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>


### PR DESCRIPTION
Hi again,

I had an issue with the IvyDE configuration, as the configuration was workspace relative, not project relative. Since I (and probably many others :)) am not using the workspace to hold the projects' code, the configuration didn't work out of the box. Here a PR to change the Ivy configuration so it's derived from the project's location, not the workspace.

Thanks!
