### PR TITLE
bump pentaho version to 6.1.0.1-196

### DIFF
--- a/java_server/build.properties
+++ b/java_server/build.properties
@@ -19,4 +19,4 @@ project.use-full-dist=true
 ivy.default.sub-configs=internal,external
 ivy.use.symlinks=false
 
-pentaho-reporting.version=5.4-SNAPSHOT
+pentaho-reporting.version=6.1.0.1-196


### PR DESCRIPTION
Hi,

time to upgrade, isn't it? :-) FWIW, our internal tests are ok.
